### PR TITLE
Ximera class file option "tikzexport" in order to dump the tikzpictures

### DIFF
--- a/ximera.cls
+++ b/ximera.cls
@@ -80,11 +80,32 @@
 \DeclareOption{space}{\spacetrue}
 %% This basically works for exercises, though page breaks are weird. 
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% tikzexport will activate standalone with "tikz"
+%
+% this exports each tikzpicture as a separate page in the PDF, which
+% is run in a sandboxed copy of pdflatex
+%
+\newif\iftikzexport
+\tikzexportfalse
+\DeclareOption{tikzexport}{%
+  \tikzexporttrue%
+}
+
 \DeclareOption*{%
   \PassOptionsToClass{\CurrentOption}{article}%
 }
 \ProcessOptions\relax
 \LoadClass{article}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% externalize tikz images
+\PassOptionsToPackage{table}{xcolor}
+\RequirePackage{tikz}
+\iftikzexport
+  \usetikzlibrary{external}
+  \tikzexternalize[prefix=./]
+\fi
 
 \RequirePackage[colorlinks=true,urlcolor=blue]{hyperref}
 \RequirePackage{enumitem}
@@ -92,7 +113,7 @@
 \RequirePackage{titletoc} 
 \RequirePackage{titling}  
 \RequirePackage{url}
-\RequirePackage[table]{xcolor}
+\RequirePackage{xcolor}
 \RequirePackage{pgfplots}
 \usepgfplotslibrary{groupplots}
 \usetikzlibrary{calc}


### PR DESCRIPTION
This request also pulls out the table option from xcolor, in order to avoid potential clashes.

On the server, pdflatex is actually run (in a sandbox) with the ximera.cls using the tikzexport class option, in order to pull out the tikz images.